### PR TITLE
Updating ProjectPage.js

### DIFF
--- a/src/component/projects/ProjectPage.js
+++ b/src/component/projects/ProjectPage.js
@@ -83,7 +83,7 @@ class ProjectPage extends Component {
       }
       return(
         <div key={key}>
-          <h2 style = {{color:Primary, marginBottom:'50px', marginTop:'50px'}}><strong>{key.charAt(0).toUpperCase() + key.slice(1).split(/(?=[A-Z])/).join(" ")}</strong></h2>
+          <h2 style = {{color:Primary, marginBottom:'50px', marginTop:'50px'}}><strong>{key.charAt(0).toUpperCase() + key.slice(1).split(/(?=[A-Z]|and)+/).join(" ")}</strong></h2>
           <h4>{this.state.data[key]}</h4>
         </div>
       );


### PR DESCRIPTION
Correcting error on project pages. "Majors Preparationand Interests" will now be "Majors Preparation and Interests".
Note: If the titles of the subsections in the project pages ever contain the substring "and," (e.g. "standard") it will split up that word ("St andard").